### PR TITLE
Update png logo

### DIFF
--- a/behaviors.xml
+++ b/behaviors.xml
@@ -3,7 +3,7 @@
    <name>Behaviors</name>
    <key>behaviors</key>
    <state>stable</state>
-   <logo>https://github.com/yllen/behaviors/blob/master/behaviors.png</logo>
+   <logo>https://raw.githubusercontent.com/yllen/behaviors/master/behaviors.png</logo>
    <description>
       <short>
          <fr><![CDATA[Cette extension permet d'ajouter des comportements optionnels à GLPI.]]></fr>


### PR DESCRIPTION
Hello @yllen 

Je suis de retour de congés et du coup j'ai mis à jour le xml sur le site des plugins.
Il reste une dernière erreur, l'url du logo pointe vers la prévisualisation de github et non vers le png directement.

Voici la correction nécessaire