### PR TITLE
Block problems/changes with open tasks

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @version $Id$
+ * @version $Id: config.class.php 338 2021-03-30 12:36:31Z yllen $
  -------------------------------------------------------------------------
 
  LICENSE
@@ -108,6 +108,8 @@ class PluginBehaviorsConfig extends CommonDBTM {
                      `groupasset` tinyint(1) NOT NULL default '0',
                      `clone` tinyint(1) NOT NULL default '0',
                      `is_tickettasktodo` tinyint(1) NOT NULL default '0',
+                     `is_problemtasktodo` tinyint(1) NOT NULL default '0',
+                     `is_changetasktodo` tinyint(1) NOT NULL default '0',
                      `date_mod` datetime default NULL,
                      `comment` text,
                      PRIMARY KEY  (`id`)
@@ -208,6 +210,10 @@ class PluginBehaviorsConfig extends CommonDBTM {
                         ['after' => 'use_assign_user_group']);
          $mig->addField($table, 'is_ticketcategory_mandatory_on_assign', 'bool',
                         ['after' => 'is_ticketcategory_mandatory']);
+         
+         // as PR#5
+         $mig->addField($table, 'is_problemtasktodo', 'bool', ['after' => 'is_tickettasktodo']);
+         $mig->addField($table, 'is_changetasktodo', 'bool', ['after' => 'is_tickettasktodo']);
       }
 
    }
@@ -396,6 +402,18 @@ class PluginBehaviorsConfig extends CommonDBTM {
       echo "<td>".__('Block the solving/closing of a the ticket if task do to', 'behaviors');
       echo "</td><td>";
       Dropdown::showYesNo("is_tickettasktodo", $config->fields['is_tickettasktodo']);
+      echo "</td><td colspan='2'></td></tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Block the solving/closing of a problem if task do to', 'behaviors');
+      echo "</td><td>";
+      Dropdown::showYesNo("is_problemtasktodo", $config->fields['is_problemtasktodo']);
+      echo "</td><td colspan='2'></td></tr>";
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Block the solving/closing of a change if task do to', 'behaviors');
+      echo "</td><td>";
+      Dropdown::showYesNo("is_changetasktodo", $config->fields['is_changetasktodo']);
       echo "</td><td colspan='2'></td></tr>";
 
       echo "<tr class='tab_bg_1'>";

--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -128,12 +128,12 @@ class PluginBehaviorsITILSolution {
                                                    'behaviors'), true, ERROR);
                return;
             }
-         if ($config->getField('is_tickettasktodo')) {
+         if ($config->getField('is_problemtasktodo')) {
             foreach($DB->request('glpi_problemtasks',
                                  ['problems_id' => $problem->getField('id')]) as $task) {
                if ($task['state'] == 1) {
                   $soluce->input = false;
-                  Session::addMessageAfterRedirect(__("You cannot solve/close a ticket with task do to",
+                  Session::addMessageAfterRedirect(__("You cannot solve/close a problem with task do to",
                                                    'behaviors'), true, ERROR);
                   return;
                }
@@ -144,12 +144,12 @@ class PluginBehaviorsITILSolution {
       $change = new Change();
       if ($change->getFromDB($soluce->input['items_id'])
           && $soluce->input['itemtype'] == 'Change') {
-         if ($config->getField('is_tickettasktodo')) {
+         if ($config->getField('is_changetasktodo')) {
             foreach($DB->request('glpi_changetasks',
                                  ['changes_id' => $change->getField('id')]) as $task) {
                if ($task['state'] == 1) {
                   $soluce->input = false;
-                  Session::addMessageAfterRedirect(__("You cannot solve/close a ticket with task do to",
+                  Session::addMessageAfterRedirect(__("You cannot solve/close a change with task do to",
                                                    'behaviors'), true, ERROR);
                   return;
                }
@@ -301,22 +301,22 @@ class PluginBehaviorsITILSolution {
          }
       }
       if ($ticket->getType() == 'Problem') {
-         if ($config->getField('is_tickettasktodo')) {
+         if ($config->getField('is_problemtasktodo')) {
             foreach ($DB->request('glpi_problemtasks',
                                  ['problems_id' => $ticket->getField('id')]) as $task) {
                if ($task['state'] == 1) {
-                  $warnings[] = __("You cannot solve/close a ticket with task do to", 'behaviors');
+                  $warnings[] = __("You cannot solve/close a problem with task do to", 'behaviors');
                   break;
                }
             }
          }
       }
       if ($ticket->getType() == 'Change') {
-         if ($config->getField('is_tickettasktodo')) {
+         if ($config->getField('is_changetasktodo')) {
             foreach ($DB->request('glpi_changetasks',
                                  ['changes_id' => $ticket->getField('id')]) as $task) {
                if ($task['state'] == 1) {
-                  $warnings[] = __("You cannot solve/close a ticket with task do to", 'behaviors');
+                  $warnings[] = __("You cannot solve/close a change with task do to", 'behaviors');
                   break;
                }
             }


### PR DESCRIPTION
As requested in Issue #5, now problems and changes can't be closed if there's an open task associated to them. This is controlled by the same option that enable this behavior for tickets. I do not changed existing variables names and messages to not mess with translation.