### PR TITLE
Fix undefined default_key_sign on update

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -76,10 +76,10 @@ class PluginBehaviorsConfig extends CommonDBTM {
       global $DB;
 
       $table = 'glpi_plugin_behaviors_configs';
+      $default_charset   = DBConnection::getDefaultCharset();
+      $default_collation = DBConnection::getDefaultCollation();
+      $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
       if (!$DB->tableExists($table)) { //not installed
-         $default_charset   = DBConnection::getDefaultCharset();
-         $default_collation = DBConnection::getDefaultCollation();
-         $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
 
          $query = "CREATE TABLE `". $table."`(
                      `id` int $default_key_sign NOT NULL,


### PR DESCRIPTION
On plugin update : 

```
[2022-06-23 09:04:06] glpiphplog.WARNING:   *** PHP Warning (2): Undefined variable $default_key_sign in C:\wamp64\www\glpi\plugins\behaviors\inc\config.class.php at line 154
  Backtrace :
  plugins\behaviors\hook.php:41                      PluginBehaviorsConfig::install()
  src\Plugin.php:779                                 plugin_behaviors_install()
  front\plugin.form.php:51                           Plugin->install()
```
  