### PR TITLE
Fix is_problemsolutiontype_mandatory beforeAdd

### DIFF
--- a/inc/itilsolution.class.php
+++ b/inc/itilsolution.class.php
@@ -124,8 +124,8 @@ class PluginBehaviorsITILSolution {
           && ($soluce->input['itemtype'] == 'Problem')) {
 
          if ($config->getField('is_problemsolutiontype_mandatory')
-             && ($soluce->input['solutiontypes_id']
-                 && ($soluce->input['solutiontypes_id'] == 0))) {
+             && (empty($soluce->input['solutiontypes_id'])
+                 || ($soluce->input['solutiontypes_id'] == 0))) {
             $soluce->input = false;
             Session::addMessageAfterRedirect(__("Type of solution is mandatory before problem is solved/closed",
                                                 'behaviors'), true, ERROR);


### PR DESCRIPTION
Looks like in v 10.0.2 solutiontypes_id is empty if not selected in dropdown while adding a solution on Problem. 
Not sure whether it is ever passed as 0 (maybe during update).
Make sure both are checked empty and 0.