### PR TITLE
fix(core): do not filter asset from CLI context

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -527,6 +527,10 @@ class PluginBehaviorsConfig extends CommonDBTM {
       $condition = "";
       list($itemtype, $condition) = $item;
 
+      if (isCommandLine()) {
+         return [$itemtype, $condition];
+      }
+
       $dbu = new DbUtils();
 
       $config = PluginBehaviorsConfig::getInstance();


### PR DESCRIPTION
Do not filter asset from CLI context

![image](https://user-images.githubusercontent.com/7335054/185398913-e1803ceb-e73d-4081-93d2-44820ca38316.png)

```taskscheduler``` automatic action from ```glpiinventory``` or ```fusioninventory``` can't get related computer because of these options (from CLI context). 

fix : https://github.com/glpi-project/glpi-inventory-plugin/issues/198
Best regards