### PR TITLE
Replace outdated $iterator->next() calls

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -138,7 +138,7 @@ class PluginBehaviorsTicket {
       $result = $DB->request($last);
 
       $querylast = '';
-       if ($data = $result->next()) {
+       if ($data = $result->current()) {
          $object = new $target->obj->userlinkclass();
          if ($object->getFromDB($data['lastid'])) {
             $querylast = " AND `$userlinktable`.`users_id` = '".$object->fields['users_id']."'";
@@ -219,7 +219,7 @@ class PluginBehaviorsTicket {
                 'WHERE'  => [$grouplinktable.'.'.$fkfield => $target->obj->fields["id"],
                              $grouplinktable.'.type'      => $type]];
 
-      if ($data = $result->next()) {
+      if ($data = $result->current()) {
          $object    = new $target->obj->grouplinkclass();
          if ($object->getFromDB($data['lastid'])) {
             $query['WHERE']['groups_id'] = $object->fields['groups_id'];
@@ -247,7 +247,7 @@ class PluginBehaviorsTicket {
                   'WHERE'  => [$supplierlinktable.'.'.$fkfield => $target->obj->fields["id"]]];
 
          $result = $DB->request($last);
-         $data = $result->next();
+         $data = $result->current();
 
          $query = ['SELECT'    => 'glpi_suppliers.email AS email',
                    'DISTINCT'  => true,


### PR DESCRIPTION
Some feature are not working correctly because of outdated calls to `$iterator->next()`, for example the `getLastLinkedGroupByType` method used for notifications will throw the following warning:
```
[2022-10-17 10:53:33] glpiphplog.WARNING:   *** PHP Warning (2): Attempt to read property "fields" on null in /home/aclai/localhost/glpi/10.0-bugfixes/plugins/behaviors/inc/ticket.class.php at line 230
  Backtrace :
  plugins/behaviors/inc/ticket.class.php:105         PluginBehaviorsTicket::getLastLinkedGroupByType()
  src/Plugin.php:1478                                PluginBehaviorsTicket::addActionTargets()
  src/NotificationTarget.php:1260                    Plugin::doHook()
  src/NotificationEventAbstract.php:94               NotificationTarget->addForTarget()
  src/NotificationEvent.php:187                      NotificationEventAbstract::raise()
  plugins/escalade/inc/ticket.class.php:342          NotificationEvent::raiseEvent()
  plugins/escalade/hook.php:430                      PluginEscaladeTicket::processAfterAddGroup()
  src/Plugin.php:1478                                plugin_escalade_item_add_group_ticket()
  src/CommonDBTM.php:1371                            Plugin::doHook()
  src/CommonITILObject.php:8228                      CommonDBTM->add()
  src/CommonITILObject.php:1855                      CommonITILObject->updateActors()
  src/Ticket.php:1586                                CommonITILObject->post_updateItem()
  src/CommonDBTM.php:1719                            Ticket->post_updateItem()
  front/ticket.form.php:84                           CommonDBTM->update()
```

Since GLPI 10, `$iterator->next()` do not return anything.
To get the first item of a newly initialized iterator, you must call `$iterator->current()` .

Full details on why this core change was done can be found here: https://github.com/glpi-project/glpi/pull/9683
