### PR TITLE
Added option to display items of child groups

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -113,6 +113,7 @@ class PluginBehaviorsConfig extends CommonDBTM {
                      `is_tickettasktodo` tinyint NOT NULL default '0',
                      `is_problemtasktodo` tinyint NOT NULL default '0',
                      `is_changetasktodo` tinyint NOT NULL default '0',
+                     `show_child_groups_items` tinyint NOT NULL default '0',
                      `date_mod` timestamp NULL DEFAULT NULL,
                      `comment` text,
                      PRIMARY KEY  (`id`)
@@ -222,6 +223,10 @@ class PluginBehaviorsConfig extends CommonDBTM {
 
          //version 2.7.0
          $mig->changeField($table, 'date_mod', 'date_mod', "timestamp NULL DEFAULT NULL");
+         
+         //version ?
+         $mig->addField($table, 'show_child_groups_items', 'bool', ['after' => 'is_changetasktodo']);
+         
       }
 
    }
@@ -314,7 +319,7 @@ class PluginBehaviorsConfig extends CommonDBTM {
       Dropdown::showYesNo("is_ticketrealtime_mandatory",
                           $config->fields['is_ticketrealtime_mandatory']);
       echo "</td><th colspan=2' class='center'>".__('Update of a problem');
-      echo "</th></tr>";
+      echo "</th></tr>";      
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Category is mandatory before ticket is solved/closed', 'behaviors')."</td><td>";
@@ -381,7 +386,7 @@ class PluginBehaviorsConfig extends CommonDBTM {
       echo "<td>".__("Use the technician's group", "behaviors")."</td><td>";
       Dropdown::showFromArray('use_assign_user_group_update', $yesnoall,
                               ['value' => $config->fields['use_assign_user_group_update']]);
-      echo "</td><th colspan='2' class='center'>".__('Comments');
+      echo "</td><th colspan='2' class='center'>".__('General');
       echo "</th></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
@@ -389,23 +394,32 @@ class PluginBehaviorsConfig extends CommonDBTM {
       echo "</td><td>";
       Dropdown::showYesNo("is_ticketlocation_mandatory",
                            $config->fields['is_ticketlocation_mandatory']);
-      echo "<td rowspan='7' colspan='2' class='center'>";
-      Html::textarea(['name'            => 'comment',
-                      'value'           => $config->fields['comment'],
-                      'cols'            => '60',
-                      'rows'            => '12',
-                      'enable_ricktext' => false]);
-      echo "</td></tr>";
+      echo "</td>";
+
+      echo "<td>".__('Show Items of child Groups', 'behaviors');
+      echo "</td><td>";
+      Dropdown::showYesNo("show_child_groups_items",
+                           $config->fields['show_child_groups_items']);
+      echo "</td></tr>";      
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Task category is mandatory in a task', 'behaviors')."</td><td>";
       Dropdown::showYesNo("is_tickettaskcategory_mandatory",
       $config->fields['is_tickettaskcategory_mandatory']);
-      echo "</td></tr>";
+      echo "</td><th colspan='2' class='center'>".__('Comments');
+      echo "</th></tr>\n";
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__("Deny change of ticket's creation date", "behaviors")."</td><td>";
-      Dropdown::showYesNo("is_ticketdate_locked", $config->fields['is_ticketdate_locked']);
+      Dropdown::showYesNo("is_ticketdate_locked", $config->fields['is_ticketdate_locked']);      
+      echo "</td>";
+
+      echo "<td rowspan='5' colspan='2' class='center'>";
+      Html::textarea(['name'            => 'comment',
+                      'value'           => $config->fields['comment'],
+                      'cols'            => '60',
+                      'rows'            => '12',
+                      'enable_ricktext' => false]);
       echo "</td></tr>";
 
       echo "<tr class='tab_bg_1'>";

--- a/inc/session.class.php
+++ b/inc/session.class.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ -------------------------------------------------------------------------
+
+ LICENSE
+
+ This file is part of Behaviors plugin for GLPI.
+
+ Behaviors is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Behaviors is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with Behaviors. If not, see <http://www.gnu.org/licenses/>.
+
+ @package   behaviors
+ @author    Remi Collet, Nelly Mahu-Lasson, Riccardo Bicelli
+ @copyright Copyright (c) 2010-2022 Behaviors plugin team
+ @license   AGPL License 3.0 or (at your option) any later version
+            http://www.gnu.org/licenses/agpl-3.0-standalone.html
+ @link      https://forge.glpi-project.org/projects/behaviors
+ @link      http://www.glpi-project.org/
+ @since     version 0.83.4
+
+ --------------------------------------------------------------------------
+*/
+
+use Group;
+
+class PluginBehaviorsSession extends PluginBehaviorsCommon {   
+
+   
+   static function LoadChildGroups() {
+   
+      $config = PluginBehaviorsConfig::getInstance();
+
+      if (($config->getField('show_child_groups_items') > 0)) { 
+         
+         foreach ( $_SESSION["glpigroups"] as $glpi_group ) {       
+         
+            self::LoadGroupsRecursive($glpi_group);
+         
+         }
+      
+      }
+   }
+
+   /**
+    * Iterate through direct assigned groups and adds child groups
+    * to session variable, in order to let the search and permissions
+    * work with parent groups
+    * @param mixed $group_id
+    * @return void
+    */
+   static function LoadGroupsRecursive($group_id){
+    
+      /** @var \DBmysql $DB */
+      global $DB;
+  
+      $iterator = $DB->request([
+          'SELECT'    => Group::getTable() . '.id',
+          'FROM'      => Group::getTable(),            
+          'WHERE'     => [
+              Group::getTable() . '.groups_id' => $group_id
+          ] + getEntitiesRestrictCriteria(
+              Group::getTable(),
+              'entities_id',
+              $_SESSION['glpiactiveentities'],
+              true
+          )
+      ]);
+  
+      foreach ($iterator as $data) {
+
+          $_SESSION["glpigroups"][] = $data["id"];          
+          self::LoadGroupsRecursive($data["id"]);
+      
+      }
+  
+  }
+}

--- a/locales/it_IT.po
+++ b/locales/it_IT.po
@@ -149,7 +149,7 @@ msgstr "La categoria dell'attività è obbligatoria"
 
 #: inc/config.class.php:373
 msgid "Deny change of ticket's creation date"
-msgstr "Nega la possibilitù di cambiare la data di creazione della chiamata"
+msgstr "Nega la possibilità di cambiare la data di creazione della chiamata"
 
 #: inc/config.class.php:378
 msgid "Protect from simultaneous update"
@@ -235,3 +235,11 @@ msgstr "Impossibile salvare, l'elemento è stato aggiornato"
 #: inc/tickettask.class.php:96
 msgid "You cannot change status of a task in a solved ticket"
 msgstr "Non è possibile modificare lo stato di un'attività in una chiamata risolta"
+
+#: config.class.php:389
+msgid "General"
+msgstr "Generale"
+
+#: config.class.php:399
+msgid "Show Items of child Group"
+msgstr "Mostra gli elementi dei Gruppi Figlio"

--- a/setup.php
+++ b/setup.php
@@ -97,6 +97,7 @@ function plugin_init_behaviors() {
 
    $PLUGIN_HOOKS['add_default_where']['behaviors'] = ['PluginBehaviorsConfig', 'add_default_where'];
 
+   $PLUGIN_HOOKS['change_entity']['behaviors'] = ['PluginBehaviorsSession', 'LoadChildGroups'];
 }
 
 


### PR DESCRIPTION
Hello,
this my first time working on a GLPI plugin, so be patient.
I noticed that standard behavior doesn't take in account parent groups when viewing tickets: if a ticket is assigned to a group a user ssociated to its parent group couldn't see the ticket.
With this added behavior:

![immagine](https://github.com/user-attachments/assets/88544153-a77d-47dc-810d-3f76652b6c45)

The user can see ticket and items associated to child groups of parent which user belongs to.